### PR TITLE
fix: app.js components folder to lowercase

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -1,13 +1,13 @@
 import './App.css';
 import { Route, Redirect, Switch } from 'react-router-dom';
 
-import Login from './Components/login';
-import Home from './Components/home';
-import NewAssignment from './Components/newAssignment';
-import StudentEntry from './Components/studentEntry';
+import Login from './components/login';
+import Home from './components/home';
+import NewAssignment from './components/newAssignment';
+import StudentEntry from './components/studentEntry';
 
-import Layout from './Components/Layout';
-import auth from './Components/auth';
+import Layout from './components/Layout';
+import auth from './components/auth';
 import React from 'react';
 
 function App() {


### PR DESCRIPTION
Fixes this issue from #10 
![image](https://user-images.githubusercontent.com/62587150/131950998-944f57e9-ee14-4c69-9b39-a6797a030ac4.png)

### Problem
 Components folder in import statements in the `app.js` had a capital C