### PR TITLE
Cfp Student class page

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -6,6 +6,7 @@ import AdminHome from './components/adminHome';
 import NewAssignment from './components/newAssignment';
 import StudentEntry from './components/studentEntry';
 import StudentHome from './components/studentHome';
+import StudentClass from './components/studentClass';
 import Layout from './components/Layout';
 import auth from './components/auth';
 import React from 'react';
@@ -31,6 +32,7 @@ function App() {
           <RouteWrapper path='/new-task' component={NewAssignment} layout={Layout} />
           <RouteWrapper path='/join-task' component={StudentEntry} layout={Layout} />
           <RouteWrapper path='/student-home' component={StudentHome} layout={Layout} />
+          <RouteWrapper path='/student/class' component={StudentClass} layout={Layout} />
           {/* If the route doesn't exist, default to /home */}
           <Redirect to='/admin-home' />
         </Switch>

--- a/src/components/studentClass.js
+++ b/src/components/studentClass.js
@@ -1,20 +1,71 @@
 import React from 'react';
 import styles from "./studentClass.module.css";
 
+
+// TODO: update api functions for the GetSurvey and GetGroup to actually return data, currently they are just returning bools
+
+/**
+ * Attempts to fetch a survey from the db and return whether it is true or not  
+ * @param {string} subjectName The identifier for the subject being fetched
+ * @returns boolean value as to whether there is a survey available for that subject for that student 
+ */
+const GetSurvey = async (subjectName) => {
+	try {
+		const surveyFetch = await fetch('http://127.0.0.1:8000/surveys', {
+			method: 'POST',
+			body: JSON.stringify({
+				subjectName,
+			})
+		})
+
+		return !!surveyFetch; //returns a boolean depending on results
+
+	} catch (error) {
+		console.error(error);
+		return false;
+	}
+}
+
+/**
+ * Gets the student's group  and returns a bool for if the student is assigned a group
+ * @param {string} subjectName The identifier for the subject being fetched
+ * @param {string} studentId The identifier for the student's group being fetched
+ * @returns boolean value as to whether there is a group for that student forthe subject
+ */
+const GetGroup = async (subjectName, studentId = "student1") => {
+	try {
+		const groupFetch = await fetch('http://127.0.0.1:8000/groups', {
+			method: 'POST',
+			body: JSON.stringify({
+				subjectName,
+				studentId
+			})
+		})
+
+		return !!groupFetch; //returns a boolean depending on results
+
+	} catch (error) {
+		console.error(error);
+		return false;
+	}
+}
+
 const StudentClass = (props) => {
 	const { subjectName } = props.location;
+	const surveyAvailable = GetSurvey(subjectName);
+	const assignedGroup = GetGroup(subjectName);
+
 	return (
 		<div>
 			<h1>Welcome to {subjectName}</h1>
 			<div className={styles.options}>
 				<div className={styles.column}>
-					<h3>Group Options</h3>
-					<div>Join a group or see your current group</div>
-					<div>View all groups</div>	
+					{/* TODO: flip disabled prop for enrolled group once backend is setup (should be disable if a group doesn't exist) */}
+					<button className={styles.btn} disabled={assignedGroup}>View enrolled group</button>
+					<button className={styles.btn}>View all groups</button>
 				</div>
 				<div className={styles.column}>
-					<h3>Surveys</h3>
-					<div>Take the available survey</div>
+					<button className={styles.btn} disabled={!surveyAvailable}>Take the survey to assign yourself to a group</button>
 				</div>
 			</div>
 		</div>

--- a/src/components/studentClass.js
+++ b/src/components/studentClass.js
@@ -1,0 +1,24 @@
+import React from 'react';
+import styles from "./studentClass.module.css";
+
+const StudentClass = (props) => {
+	const { subjectName } = props.location;
+	return (
+		<div>
+			<h1>Welcome to {subjectName}</h1>
+			<div className={styles.options}>
+				<div className={styles.column}>
+					<h3>Group Options</h3>
+					<div>Join a group or see your current group</div>
+					<div>View all groups</div>	
+				</div>
+				<div className={styles.column}>
+					<h3>Surveys</h3>
+					<div>Take the available survey</div>
+				</div>
+			</div>
+		</div>
+	)
+}
+
+export default StudentClass;

--- a/src/components/studentClass.module.css
+++ b/src/components/studentClass.module.css
@@ -4,9 +4,40 @@
 	gap: 20px;
 	width: 100vw;
 	max-width: 100%;
-	justify-content: space-around;	
+	padding: 40px;
+	justify-content: center;
 }
 
-.column{
+.column {
+	min-height: 500px;
+	width: max-content;
+	min-width: 40%;
+	display: flex;
+	flex-direction: column;
+	align-content: center;
+	justify-content: center;
+	align-items: center;
+	gap: 30px;
+}
 
+button:disabled {
+	cursor: not-allowed;
+	pointer-events: all !important;
+	box-shadow: none;
+	background-color: grey;
+	border: 1px solid grey;
+}
+
+.btn {
+	background-color: #4a77d4;
+	color: white;
+	padding: 14px 28px;
+	font-size: 20px;
+	cursor: pointer;
+	border-radius: 20px;
+	max-width: 400px;
+	width: 100%;
+	box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.2), 0 1px 2px rgba(0, 0, 0, 0.5);
+	border: 1px solid #3762bc;
+	padding: 2em;
 }

--- a/src/components/studentClass.module.css
+++ b/src/components/studentClass.module.css
@@ -1,0 +1,12 @@
+.options {
+	display: flex;
+	flex-direction: row;
+	gap: 20px;
+	width: 100vw;
+	max-width: 100%;
+	justify-content: space-around;	
+}
+
+.column{
+
+}

--- a/src/components/studentHome.js
+++ b/src/components/studentHome.js
@@ -6,15 +6,15 @@ import { Link } from 'react-router-dom';
 const classes = [
 	{
 		id: "01231234",
-		name: "class_1"
+		name: "Software Engineering Studio 1a"
 	},
 	{
 		id: "89786231",
-		name: "class_2"
+		name: "Data Structures and Algorithms"
 	},
 	{
 		id: "89712121",
-		name: "class_3"
+		name: "Engineering Communication"
 	}
 ];
 

--- a/src/components/studentHome.js
+++ b/src/components/studentHome.js
@@ -1,11 +1,40 @@
 import React from 'react';
 import styles from "./studentHome.module.css"
+import { Link } from 'react-router-dom';
+
+// dumby class list for demo before db connection
+const classes = [
+	{
+		id: "01231234",
+		name: "class_1"
+	},
+	{
+		id: "89786231",
+		name: "class_2"
+	},
+	{
+		id: "89712121",
+		name: "class_3"
+	}
+];
 
 const StudentHome = () => {
 	return (
 		<div>
 			<h1>student homepage </h1>
-			<div className={styles.mainContainer}>This is the student box</div>
+			<div className={styles.mainContainer}>This is the student box
+				{classes ? (classes.map(studentClass => 
+					<div key={studentClass.id}>
+					<Link to={{
+						pathname: "/student/class",
+						subjectName: studentClass.name
+					}}
+					>View {studentClass.name}!</Link>
+					</div>
+				)) :
+					(<div>Sorry you haven't joined/been added to any classes yet</div>)
+				}
+			</div>
 		</div>
 	)
 }


### PR DESCRIPTION
Class frontend classes page based on wireframe
![image](https://user-images.githubusercontent.com/62587150/135026685-67e5d8fa-5142-4ff2-a611-a0d0e021140e.png)

as-a-student-i-want-to-be-able-to-individually-view-each-class-page-so-i-only-see-groups-surveys-related-to-that-one-subject

Adds stubbed data for student homepage selecting classes so that we can get to individual class pages

Added non-working api fetches to be implemented later